### PR TITLE
Added a (.) in vocab to represent disconnected structures

### DIFF
--- a/organ/mol_metrics.py
+++ b/organ/mol_metrics.py
@@ -321,6 +321,8 @@ def build_vocab(smiles=None, pad_char='_', start_char='^'):
     chars = chars + ['@']
     # directional bonds
     chars = chars + ['/', '\\']
+    # Disconnected structures
+    chars = chars + ['.']
 
     char_dict = {}
     char_dict[start_char] = 0


### PR DESCRIPTION
I was running the code by running example.py and then I encountered an error which said

> KeyError: '.'

I found that in char_dict, a (.) was missing and checking on SMILES documentation it represented "disconnected structures". 

[Reading SMILES 3.7](http://opensmiles.org/opensmiles.html )